### PR TITLE
fix: urlSpaceRegex can be setted via attribute

### DIFF
--- a/packages/furo-route/src/furo-app-flow-router.js
+++ b/packages/furo-route/src/furo-app-flow-router.js
@@ -84,6 +84,15 @@ class FuroAppFlowRouter extends FBP(LitElement) {
        *  - if you want to link to a target outside your app add **EXTERNAL_LINK:** followed by the link
        */
       config: { type: Array },
+
+      /**
+       * attribute url-space-regex
+       * e.g. url-space-regex="^${window.APPROOT}/"
+       */
+      urlSpaceRegex: {
+        type: String,
+        attribute: 'url-space-regex',
+      },
     };
   }
 


### PR DESCRIPTION
the value of urlSpaceRegex for path-based-routing can be setted via Atrribte "url-space-regex" . 
in this fix the Mapping of attribute is added to make it really works. 