### PR TITLE
fix: prevent multi `close-request` eventlistening on filednode in bas…

### DIFF
--- a/packages/furo-route/src/lib/BasePanel.js
+++ b/packages/furo-route/src/lib/BasePanel.js
@@ -24,11 +24,13 @@ export class BasePanel extends FBP(LitElement) {
      */
     this._FBPAddWireHook('--navNode', fieldNode => {
       this.treeNode = fieldNode;
-      fieldNode.addEventListener('close-requested', e => {
-        if (this.onCloseRequest(e)) {
-          this.closePanel();
-        }
-      });
+      if(!fieldNode.__eventListener["close-requested"]) {
+        fieldNode.addEventListener('close-requested', e => {
+          if (this.onCloseRequest(e)) {
+            this.closePanel();
+          }
+        });
+      }
     });
 
     /**


### PR DESCRIPTION
prevent multi `close-request` eventlistening on filednode in base-panel. otherwise the `close-requested` event will be added to listener more than once when panel is deleted and added again. in this case the panel will be closed several times when a `close-requested` event comes and then causes the error in panel coordinator. 