### PR TITLE
fix: furo-page should remove `hidden` for the current page when the c…

### DIFF
--- a/packages/furo-app/src/furo-app-drawer.js
+++ b/packages/furo-app/src/furo-app-drawer.js
@@ -31,7 +31,6 @@ class FuroAppDrawer extends FBP(LitElement) {
         e.detail.drawer = this;
       }
     });
-
   }
 
   /**
@@ -210,7 +209,6 @@ class FuroAppDrawer extends FBP(LitElement) {
       this.close();
     });
 
-
     // register resize listener
     if (!this.permanent) {
       if (window.ResizeObserver) {
@@ -242,7 +240,6 @@ class FuroAppDrawer extends FBP(LitElement) {
       }
     }
 
-
     // initial size
     const cr = this.getBoundingClientRect();
     this.__isFloating = cr.width <= this.floatBreakpoint;
@@ -251,10 +248,9 @@ class FuroAppDrawer extends FBP(LitElement) {
     /**
      * Set the transition effect after the first render. Otherwise we get a flickering effect
      */
-    setTimeout(()=>{
-      drawer.style.transitionDuration = "200ms";
-    },201);
-
+    setTimeout(() => {
+      drawer.style.transitionDuration = '200ms';
+    }, 201);
 
     const drag = this.shadowRoot.getElementById('drag');
     const backdrop = this.shadowRoot.getElementById('backdrop');

--- a/packages/furo-route/src/furo-pages.js
+++ b/packages/furo-route/src/furo-pages.js
@@ -94,8 +94,7 @@ class FuroPages extends LitElement {
       }
     }
     if (this._lastPage) {
-
-      if(this._lastPage.hasAttribute('hidden')) {
+      if (this._lastPage.hasAttribute('hidden')) {
         this._lastPage.removeAttribute('hidden');
       }
       this._lastPage.setAttribute(this._attrForSelected, '');

--- a/packages/furo-route/src/furo-pages.js
+++ b/packages/furo-route/src/furo-pages.js
@@ -94,14 +94,15 @@ class FuroPages extends LitElement {
       }
     }
     if (this._lastPage) {
-      if (page !== this._lastPageName) {
-        this._lastPage.removeAttribute('hidden');
-        this._lastPage.setAttribute(this._attrForSelected, '');
 
-        this._lastPageName = page;
-        if (this._lastPage._FBPTriggerWire !== undefined) {
-          this._lastPage._FBPTriggerWire('--pageActivated', location);
-        }
+      if(this._lastPage.hasAttribute('hidden')) {
+        this._lastPage.removeAttribute('hidden');
+      }
+      this._lastPage.setAttribute(this._attrForSelected, '');
+
+      this._lastPageName = page;
+      if (this._lastPage._FBPTriggerWire !== undefined) {
+        this._lastPage._FBPTriggerWire('--pageActivated', location);
       }
 
       // QP

--- a/packages/furo-route/src/furo-panel-coordinator.js
+++ b/packages/furo-route/src/furo-panel-coordinator.js
@@ -135,7 +135,7 @@ class FuroPanelCoordinator extends FBP(LitElement) {
 
     if (this._openPanels.length > 0) {
       // only when there is no selected navigation node
-      if(this._openPanels.every(node => node._isSelected === false)) {
+      if (this._openPanels.every(node => node._isSelected === false)) {
         // select item with same index
         this._openPanels[this._openPanels.length - 1].selectItem();
       }


### PR DESCRIPTION
when the panel is deleted and then created direkt (without navigated to other navigation node) , this panel page is blank (hidden). 
because the furo-page checks the lastPage and the current page. When they are the same the  furo-page don't remove the `hidden` attribute. 