### PR TITLE
fix: date-input fixed. prettier furo-data-money-input

### DIFF
--- a/packages/furo-data-input/src/furo-data-money-input.js
+++ b/packages/furo-data-input/src/furo-data-money-input.js
@@ -84,7 +84,7 @@ class FuroDataMoneyInput extends FBP(LitElement) {
       obj.units = Number(arr[0]);
       if (arr[1]) {
         // eslint-disable-next-line no-param-reassign
-        obj.nanos = Number.parseInt(Number(`0.${arr[1]}`) * 100000000,10);
+        obj.nanos = Number.parseInt(Number(`0.${arr[1]}`) * 100000000, 10);
       } else {
         // eslint-disable-next-line no-param-reassign
         obj.nanos = 0;

--- a/packages/furo-input/src/furo-date-input.js
+++ b/packages/furo-input/src/furo-date-input.js
@@ -90,7 +90,13 @@ class FuroDateInput extends FBP(LitElement) {
     this._value = this.value || '';
 
     this._FBPAddWireHook('--inputInput', e => {
-      Helper.triggerValueChanged(this, e);
+      // fix for e.g. by date "01.01.2000" you just want to modify the day and begin to tap 0.
+      // at this moment the value of input in wire `--inputInput` is empty.(a bug in date input?)
+      // this value has to be prevented to be send to object. because this empty value will be set to input again via `--value`.
+      // then the hole date is cleared.
+      if (e.composedPath()[0].value) {
+        Helper.triggerValueChanged(this, e);
+      }
     });
   }
 


### PR DESCRIPTION
fix for the case:
e.g. date "01.01.2000" was inputed . then you just want to modify the day and begin to tap 0.
at this moment the value of input in wire `--inputInput` is empty.(a bug in date input?)
this value has to be prevented to be send to data object. because this empty value will be set to input again via `--value`.then the hole date is cleared.