### PR TITLE
Bugfix/handling req res headers

### DIFF
--- a/packages/furo-data/src/furo-collection-agent.js
+++ b/packages/furo-data/src/furo-collection-agent.js
@@ -273,13 +273,14 @@ class FuroCollectionAgent extends FBP(LitElement) {
     this._FBPTriggerWire('--beforeRequestStart');
 
     let data;
-    if (body) {
-      data = JSON.stringify(body);
-    }
-
     // create Request object with headers and body
     const headers = new Headers(this._ApiEnvironment.headers);
-    headers.append('Content-Type', 'application/json; charset=utf-8');
+
+    if (body) {
+      data = JSON.stringify(body);
+      headers.append('Content-Type', 'application/json; charset=utf-8');
+    }
+
     const REL_NAME =
       ['prev', 'first', 'next', 'last'].indexOf(link.rel.toLowerCase()) >= 0
         ? 'Get'

--- a/packages/furo-data/src/furo-collection-agent.js
+++ b/packages/furo-data/src/furo-collection-agent.js
@@ -276,10 +276,18 @@ class FuroCollectionAgent extends FBP(LitElement) {
     if (body) {
       data = JSON.stringify(body);
     }
-    // Daten
+
+    // create Request object with headers and body
     const headers = new Headers(this._ApiEnvironment.headers);
-    const TYPE = link.type ? `application/${link.type}+json` : 'application/json';
-    headers.append('Content-Type', `${TYPE}; charset=utf-8`);
+    headers.append('Content-Type', 'application/json; charset=utf-8');
+    const REL_NAME =
+      ['prev', 'first', 'next', 'last'].indexOf(link.rel.toLowerCase()) >= 0
+        ? 'Get'
+        : link.rel.charAt(0).toUpperCase() + link.rel.slice(1).toLocaleLowerCase();
+    const ACCEPT = `application/${
+      this._ApiEnvironment.services[link.service].services[REL_NAME].data.response
+    }+json, application/json;q=0.9`;
+    headers.append('Accept', `${ACCEPT}`);
 
     const params = {};
     const r = link.href.split('?');

--- a/packages/furo-data/src/furo-custom-method.js
+++ b/packages/furo-data/src/furo-custom-method.js
@@ -81,6 +81,10 @@ class FuroCustomMethod extends FBP(LitElement) {
     this._FBPTriggerWire('--beforeRequestStart');
     let data;
     const body = {};
+
+    // create Request object with headers and body
+    const headers = new Headers(this._ApiEnvironment.headers);
+
     // check if dataObject is set and create body object
     if (dataObject) {
       // eslint-disable-next-line guard-for-in,no-restricted-syntax
@@ -92,19 +96,8 @@ class FuroCustomMethod extends FBP(LitElement) {
         }
       }
       data = JSON.stringify(body);
+      headers.append('Content-Type', 'application/json; charset=utf-8');
     }
-    /**
-     * The AbortController interface represents a controller object that allows you to abort one or more DOM requests as and when desired.)
-     * https://developer.mozilla.org/en-US/docs/Web/API/AbortController
-     * @type {AbortController}
-     * @private
-     */
-    this._abortController = new AbortController();
-    const { signal } = this._abortController;
-
-    // create Request object with headers and body
-    const headers = new Headers(this._ApiEnvironment.headers);
-    headers.append('Content-Type', 'application/json; charset=utf-8');
 
     const REL_NAME =
       link.rel.toLowerCase() === 'self'
@@ -114,6 +107,15 @@ class FuroCustomMethod extends FBP(LitElement) {
       this._ApiEnvironment.services[link.service].services[REL_NAME].data.response
     }+json, application/json;q=0.9`;
     headers.append('Accept', `${ACCEPT}`);
+
+    /**
+     * The AbortController interface represents a controller object that allows you to abort one or more DOM requests as and when desired.)
+     * https://developer.mozilla.org/en-US/docs/Web/API/AbortController
+     * @type {AbortController}
+     * @private
+     */
+    this._abortController = new AbortController();
+    const { signal } = this._abortController;
 
     return new Request(link.href, {
       signal,

--- a/packages/furo-data/src/furo-custom-method.js
+++ b/packages/furo-data/src/furo-custom-method.js
@@ -102,10 +102,18 @@ class FuroCustomMethod extends FBP(LitElement) {
     this._abortController = new AbortController();
     const { signal } = this._abortController;
 
-    // Daten
+    // create Request object with headers and body
     const headers = new Headers(this._ApiEnvironment.headers);
-    const TYPE = link.type ? `application/${link.type}+json` : 'application/json';
-    headers.append('Content-Type', `${TYPE}; charset=utf-8`);
+    headers.append('Content-Type', 'application/json; charset=utf-8');
+
+    const REL_NAME =
+      link.rel.toLowerCase() === 'self'
+        ? 'Get'
+        : link.rel.charAt(0).toUpperCase() + link.rel.slice(1).toLocaleLowerCase();
+    const ACCEPT = `application/${
+      this._ApiEnvironment.services[link.service].services[REL_NAME].data.response
+    }+json, application/json;q=0.9`;
+    headers.append('Accept', `${ACCEPT}`);
 
     return new Request(link.href, {
       signal,

--- a/packages/furo-data/src/furo-entity-agent.js
+++ b/packages/furo-data/src/furo-entity-agent.js
@@ -190,18 +190,11 @@ class FuroEntityAgent extends FBP(LitElement) {
      */
     const data = this._prepareRequestPaylod(link, dataObject);
 
-    /**
-     * The AbortController interface represents a controller object that allows you to abort one or more DOM requests as and when desired.)
-     * https://developer.mozilla.org/en-US/docs/Web/API/AbortController
-     * @type {AbortController}
-     * @private
-     */
-    this._abortController = abortController || new AbortController();
-    const { signal } = this._abortController;
-
     // create Request object with headers and body
     const headers = new Headers(this._ApiEnvironment.headers);
-    headers.append('Content-Type', 'application/json; charset=utf-8');
+    if (data) {
+      headers.append('Content-Type', 'application/json; charset=utf-8');
+    }
 
     const REL_NAME =
       link.rel.toLowerCase() === 'self'
@@ -211,6 +204,15 @@ class FuroEntityAgent extends FBP(LitElement) {
       this._ApiEnvironment.services[link.service].services[REL_NAME].data.response
     }+json, application/json;q=0.9`;
     headers.append('Accept', `${ACCEPT}`);
+
+    /**
+     * The AbortController interface represents a controller object that allows you to abort one or more DOM requests as and when desired.)
+     * https://developer.mozilla.org/en-US/docs/Web/API/AbortController
+     * @type {AbortController}
+     * @private
+     */
+    this._abortController = abortController || new AbortController();
+    const { signal } = this._abortController;
 
     return new Request(link.href, {
       signal,

--- a/packages/furo-data/src/furo-entity-agent.js
+++ b/packages/furo-data/src/furo-entity-agent.js
@@ -201,12 +201,17 @@ class FuroEntityAgent extends FBP(LitElement) {
 
     // create Request object with headers and body
     const headers = new Headers(this._ApiEnvironment.headers);
-    const TYPE = link.type ? `application/${link.type}+json` : 'application/json';
-    headers.append('Content-Type', `${TYPE}; charset=utf-8`);
+    headers.append('Content-Type', 'application/json; charset=utf-8');
 
-    // if (link.method.toLowerCase() !== 'put') {
-    //   headers.append('Content-Type', 'application/json');
-    // }
+    const REL_NAME =
+      link.rel.toLowerCase() === 'self'
+        ? 'Get'
+        : link.rel.charAt(0).toUpperCase() + link.rel.slice(1).toLocaleLowerCase();
+    const ACCEPT = `application/${
+      this._ApiEnvironment.services[link.service].services[REL_NAME].data.response
+    }+json, application/json;q=0.9`;
+    headers.append('Accept', `${ACCEPT}`);
+
     return new Request(link.href, {
       signal,
       method: link.method,

--- a/packages/furo-data/src/lib/FieldNode.js
+++ b/packages/furo-data/src/lib/FieldNode.js
@@ -225,7 +225,7 @@ export class FieldNode extends EventTreeNode {
        * if we have meta on this layer, we should update the siblings
        */
       if (furoMetaDetected) {
-        this.__updateMetaAndConstraints(furoMetaDetected,0);
+        this.__updateMetaAndConstraints(furoMetaDetected, 0);
       }
     } else {
       // update the primitive type
@@ -344,14 +344,13 @@ export class FieldNode extends EventTreeNode {
         // eslint-disable-next-line no-restricted-syntax
         for (const m in mc.meta) {
           // update the metas, the level should be checked. because the field can be data.data
-          if (this._name === field && !level){
+          if (this._name === field && !level) {
             this._meta[m] = mc.meta[m];
             // broadcast readonly changes for all ancestors
             if (m === 'readonly') {
               this.broadcastEvent(new NodeEvent('parent-readonly-meta-set', this, true));
             }
-          }
-          else if (this[field]) {
+          } else if (this[field]) {
             this[field]._meta[m] = mc.meta[m];
             // broadcast readonly changes for all ancestors
             if (m === 'readonly') {
@@ -366,10 +365,9 @@ export class FieldNode extends EventTreeNode {
         // eslint-disable-next-line no-restricted-syntax
         for (const c in mc.constraints) {
           // update the constraints
-          if (this._name === field && !level){
+          if (this._name === field && !level) {
             this._constraints[c] = mc.constraints[c];
-          }
-          else if (this[field]) {
+          } else if (this[field]) {
             this[field]._constraints[c] = mc.constraints[c];
           } else {
             // eslint-disable-next-line no-console
@@ -386,7 +384,7 @@ export class FieldNode extends EventTreeNode {
         if (this._name === field && !level) {
           // eslint-disable-next-line no-plusplus
           this._triggerDeepNodeEvent('this-metas-changed');
-        }else if (this[field]) {
+        } else if (this[field]) {
           this[field].dispatchNodeEvent(new NodeEvent('this-metas-changed', this[field], false));
         }
 
@@ -397,7 +395,7 @@ export class FieldNode extends EventTreeNode {
       const subMetaAndConstraints = { fields: {} };
       subMetaAndConstraints.fields[f.slice(1).join('.')] = mc;
       // eslint-disable-next-line no-param-reassign
-      level +=1;
+      level += 1;
       this[target].__updateMetaAndConstraints(subMetaAndConstraints, level);
     }
   }
@@ -408,7 +406,7 @@ export class FieldNode extends EventTreeNode {
    * @param event
    * @private
    */
-  _triggerDeepNodeEvent(event){
+  _triggerDeepNodeEvent(event) {
     if (this.__childNodes.length > 0) {
       // eslint-disable-next-line guard-for-in,no-restricted-syntax
       for (const index in this.__childNodes) {
@@ -416,7 +414,7 @@ export class FieldNode extends EventTreeNode {
         field._triggerDeepNodeEvent(event);
       }
     }
-    if (event && event.length){
+    if (event && event.length) {
       this.dispatchNodeEvent(new NodeEvent(event, this, false));
     }
   }

--- a/packages/furo-data/src/lib/RepeaterNode.js
+++ b/packages/furo-data/src/lib/RepeaterNode.js
@@ -299,7 +299,7 @@ export class RepeaterNode extends EventTreeNode {
    * @param event
    * @private
    */
-  _triggerDeepNodeEvent(event){
+  _triggerDeepNodeEvent(event) {
     this.__childNodes.forEach(f => {
       f._triggerDeepNodeEvent(event);
     });

--- a/packages/furo-data/test/furo-data-readonly-inheritence.test.js
+++ b/packages/furo-data/test/furo-data-readonly-inheritence.test.js
@@ -140,187 +140,188 @@ describe('furo-data-readonly-inheritence', () => {
 
   it('should set readonly on repeated field from response', done => {
     element.setAttribute('type', 'project.ProjectEntity');
-    element.injectRaw({
-      meta: {
-        fields: {
-          'data.members': {
-            meta: {
-              readonly: true,
+    element
+      .injectRaw({
+        meta: {
+          fields: {
+            'data.members': {
+              meta: {
+                readonly: true,
+              },
             },
           },
         },
-      },
-      data: {
-        id: '1',
-        cost_limit: {
-          currency_code: 'CHF',
-          display_name: "CHF 150'000.00",
-          nanos: 150000,
-          units: 0,
-        },
-        description: 'Furo Foundation',
-        display_name: "Furo Foundation, CHF 150'000.00",
-        end: {
-          day: 31,
-          display_name: '31.12.2020',
-          month: 12,
-          year: 2020,
-        },
-        members: [
-          {
-            display_name: 'John Doe, +41783332244',
-            first_name: 'John',
-            id: '1',
-            name: 'Doe',
-            phone_nr: '+41783332244',
-            skills: [],
+        data: {
+          id: '1',
+          cost_limit: {
+            currency_code: 'CHF',
+            display_name: "CHF 150'000.00",
+            nanos: 150000,
+            units: 0,
           },
+          description: 'Furo Foundation',
+          display_name: "Furo Foundation, CHF 150'000.00",
+          end: {
+            day: 31,
+            display_name: '31.12.2020',
+            month: 12,
+            year: 2020,
+          },
+          members: [
+            {
+              display_name: 'John Doe, +41783332244',
+              first_name: 'John',
+              id: '1',
+              name: 'Doe',
+              phone_nr: '+41783332244',
+              skills: [],
+            },
+            {
+              display_name: 'Jack Black, +41793331231',
+              first_name: 'Jack',
+              id: '2',
+              name: 'Black',
+              phone_nr: '+41793331231',
+              skills: [],
+            },
+          ],
+          start: {
+            day: 1,
+            display_name: '01.07.2019',
+            month: 7,
+            year: 2019,
+          },
+        },
+        links: [
           {
-            display_name: 'Jack Black, +41793331231',
-            first_name: 'Jack',
-            id: '2',
-            name: 'Black',
-            phone_nr: '+41793331231',
-            skills: [],
+            href: '/mockdata/projects/1/get.json',
+            method: 'GET',
+            rel: 'self',
+            type: 'project.ProjectEntity',
+            service: 'ProjectService',
           },
         ],
-        start: {
-          day: 1,
-          display_name: '01.07.2019',
-          month: 7,
-          year: 2019,
-        },
-      },
-      links: [
-        {
-          href: '/mockdata/projects/1/get.json',
-          method: 'GET',
-          rel: 'self',
-          type: 'project.ProjectEntity',
-          service: 'ProjectService',
-        },
-      ],
-    }).then(()=>{
-      const EntityRoot = element.data.data;
+      })
+      .then(() => {
+        const EntityRoot = element.data.data;
 
-      assert.equal(EntityRoot._isValid, true);
-      assert.equal(EntityRoot.members._meta.readonly, true);
-      assert.equal(EntityRoot.members.repeats[0].phone_nr._meta.readonly, true);
-      assert.equal(EntityRoot.members.repeats[1].phone_nr._meta.readonly, true);
+        assert.equal(EntityRoot._isValid, true);
+        assert.equal(EntityRoot.members._meta.readonly, true);
+        assert.equal(EntityRoot.members.repeats[0].phone_nr._meta.readonly, true);
+        assert.equal(EntityRoot.members.repeats[1].phone_nr._meta.readonly, true);
 
-      done();
-    });
-
+        done();
+      });
   });
 
   it('should set readonly for the whole object', done => {
     element.setAttribute('type', 'project.ProjectEntity');
 
-    element.injectRaw({
-      "data": {
-        "id": "1",
-        "cost_limit": {
-          "currency_code": "CHF",
-          "display_name": "CHF 150'000.00",
-          "nanos": 150000,
-          "units": 0
-        },
-        "description": "Furo Foundation",
-        "display_name": "Furo Foundation, CHF 150'000.00",
-        "end": {
-          "day": 31,
-          "display_name": "31.12.2020",
-          "month": 12,
-          "year": 2020
-        },
-        "members": [
-          {
-            "display_name": "John Doe, +41783332244",
-            "first_name": "John",
-            "id": "1",
-            "name": "Doe",
-            "phone_nr": "+41783332244",
-            "skills": []
-          }
-        ],
-        "start": {
-          "day": 1,
-          "display_name": "01.07.2019",
-          "month": 7,
-          "year": 2019
-        }
-      },
-      "meta": {
-        "fields": {
-          "data": {
-            "meta": {
-              "readonly": true
-            }
+    element
+      .injectRaw({
+        data: {
+          id: '1',
+          cost_limit: {
+            currency_code: 'CHF',
+            display_name: "CHF 150'000.00",
+            nanos: 150000,
+            units: 0,
           },
-          "data.description": {
-            "meta": {
-              "label": "ID label from response",
-              "options": {
-                "list": [
-                  {
-                    "@type": "type.googleapis.com/furo.Optionitem",
-                    "id": "1",
-                    "display_name": "A"
-                  },
-                  {
-                    "@type": "type.googleapis.com/furo.Optionitem",
-                    "id": "2",
-                    "display_name": "B",
-                    "selected": true
-                  }
-                ]
-              }
+          description: 'Furo Foundation',
+          display_name: "Furo Foundation, CHF 150'000.00",
+          end: {
+            day: 31,
+            display_name: '31.12.2020',
+            month: 12,
+            year: 2020,
+          },
+          members: [
+            {
+              display_name: 'John Doe, +41783332244',
+              first_name: 'John',
+              id: '1',
+              name: 'Doe',
+              phone_nr: '+41783332244',
+              skills: [],
             },
-            "constraints": {
-              "min": {
-                "is": 5,
-                "message": "minimal number"
-              },
-              "max": {
-                "is": 20,
-                "message": "Vierzehn sind genug"
-              }
-            }
-          }
-        }
-      },
-      "links": [
-        {
-          "href": "/mockdata/projects/1/get.json",
-          "method": "GET",
-          "rel": "self",
-          "type": "project.ProjectEntity",
-          "service": "ProjectService"
+          ],
+          start: {
+            day: 1,
+            display_name: '01.07.2019',
+            month: 7,
+            year: 2019,
+          },
         },
-        {
-          "href": "/mockdata/projects/1/update.json",
-          "method": "UPDATE",
-          "rel": "update",
-          "type": "project.ProjectEntity",
-          "service": "ProjectService"
-        }
-      ]
-    }).then(()=>{
-      const EntityRoot = element.data;
-      assert.equal(EntityRoot.data._meta.readonly, true);
-      assert.equal(EntityRoot.data._isValid, true);
-      assert.equal(EntityRoot.data.members._meta.label, 'Project members**');
-      assert.equal(EntityRoot.data.members.repeats[0].phone_nr._meta.readonly, true);
-      assert.equal(EntityRoot.data.display_name._meta.readonly, true);
-      assert.equal(EntityRoot.data.start.year._meta.readonly, true);
-      assert.equal(EntityRoot.data.start.month._meta.readonly, true);
-      assert.equal(EntityRoot.data.start.day._meta.readonly, true);
-      assert.equal(EntityRoot.data.end.year._meta.readonly, true);
-      assert.equal(EntityRoot.data.end.month._meta.readonly, true);
-      assert.equal(EntityRoot.data.end.day._meta.readonly, true);
-      done();
-    });
-
+        meta: {
+          fields: {
+            data: {
+              meta: {
+                readonly: true,
+              },
+            },
+            'data.description': {
+              meta: {
+                label: 'ID label from response',
+                options: {
+                  list: [
+                    {
+                      '@type': 'type.googleapis.com/furo.Optionitem',
+                      id: '1',
+                      display_name: 'A',
+                    },
+                    {
+                      '@type': 'type.googleapis.com/furo.Optionitem',
+                      id: '2',
+                      display_name: 'B',
+                      selected: true,
+                    },
+                  ],
+                },
+              },
+              constraints: {
+                min: {
+                  is: 5,
+                  message: 'minimal number',
+                },
+                max: {
+                  is: 20,
+                  message: 'Vierzehn sind genug',
+                },
+              },
+            },
+          },
+        },
+        links: [
+          {
+            href: '/mockdata/projects/1/get.json',
+            method: 'GET',
+            rel: 'self',
+            type: 'project.ProjectEntity',
+            service: 'ProjectService',
+          },
+          {
+            href: '/mockdata/projects/1/update.json',
+            method: 'UPDATE',
+            rel: 'update',
+            type: 'project.ProjectEntity',
+            service: 'ProjectService',
+          },
+        ],
+      })
+      .then(() => {
+        const EntityRoot = element.data;
+        assert.equal(EntityRoot.data._meta.readonly, true);
+        assert.equal(EntityRoot.data._isValid, true);
+        assert.equal(EntityRoot.data.members._meta.label, 'Project members**');
+        assert.equal(EntityRoot.data.members.repeats[0].phone_nr._meta.readonly, true);
+        assert.equal(EntityRoot.data.display_name._meta.readonly, true);
+        assert.equal(EntityRoot.data.start.year._meta.readonly, true);
+        assert.equal(EntityRoot.data.start.month._meta.readonly, true);
+        assert.equal(EntityRoot.data.start.day._meta.readonly, true);
+        assert.equal(EntityRoot.data.end.year._meta.readonly, true);
+        assert.equal(EntityRoot.data.end.month._meta.readonly, true);
+        assert.equal(EntityRoot.data.end.day._meta.readonly, true);
+        done();
+      });
   });
-
 });

--- a/packages/furo-data/test/furo-property-type.test.js
+++ b/packages/furo-data/test/furo-property-type.test.js
@@ -57,22 +57,22 @@ describe('furo-property-type', () => {
           display_name: 'a date',
           id: 'date',
           code: 'date',
-          "meta":{
-            "fields": {
-              "data.data": {
+          meta: {
+            fields: {
+              'data.data': {
                 meta: {
-                  "label":"test label",
-                  "readonly": true
-                }
-              }
-            }
-          }
+                  label: 'test label',
+                  readonly: true,
+                },
+              },
+            },
+          },
         },
       ],
     });
     assert.equal(element.data.type_property.repeats[0].data.display_name._value, '32 32 23');
     assert.equal(element.data.type_property.repeats[1].data.data._value, 'display_name');
-    assert.equal(element.data.type_property.repeats[1].data.data._meta.label, "test label");
+    assert.equal(element.data.type_property.repeats[1].data.data._meta.label, 'test label');
     assert.equal(element.data.type_property.repeats[1].data.data._meta.readonly, true);
     done();
   });


### PR DESCRIPTION
**Handling of the request headers**

'_accept_': always provided with the response type + json from the Furo API Spec. e.g. 'application/project.ProjectEntity+json, application/json;q=0.9'

'_content-type_': only provided if body is sent. e.g. 'application/json; charset=utf-8'