### PR TITLE
fix: When creating a service specification for the first time, /api s…

### DIFF
--- a/packages/furo-specs/_scripts/templates/make/ServiceFromType.tmpl
+++ b/packages/furo-specs/_scripts/templates/make/ServiceFromType.tmpl
@@ -78,7 +78,7 @@
       "deeplink": {
         "description":"Describe_the_query_params_if_you_have",
         "rel": "list",
-        "href": "/api/{{.name}}s",
+        "href": "/{{.name}}s",
         "method": "GET"
       }
     },
@@ -93,7 +93,7 @@
       },
       "deeplink": {
         "rel": "create",
-        "href": "/api/{{.name}}s",
+        "href": "/{{.name}}s",
         "method": "POST"
       }
     },
@@ -108,7 +108,7 @@
       },
       "deeplink": {
         "rel": "self",
-        "href": "/api/{{.name}}s/{REPLACE_THIS_WITH_YOUR_QUERY_PARAM}",
+        "href": "/{{.name}}s/{REPLACE_THIS_WITH_YOUR_QUERY_PARAM}",
         "method": "GET"
       }
     },
@@ -122,7 +122,7 @@
       "query": {},
       "deeplink": {
         "rel": "update",
-        "href": "/api/{{.name}}s/{REPLACE_THIS_WITH_YOUR_QUERY_PARAM}",
+        "href": "/{{.name}}s/{REPLACE_THIS_WITH_YOUR_QUERY_PARAM}",
         "method": "PATCH"
       }
     },
@@ -136,7 +136,7 @@
       "query": {},
       "deeplink": {
         "rel": "delete",
-        "href": "/api/{{.name}}s/{REPLACE_THIS_WITH_YOUR_QUERY_PARAM}",
+        "href": "/{{.name}}s/{REPLACE_THIS_WITH_YOUR_QUERY_PARAM}",
         "method": "DELETE"
       }
     }


### PR DESCRIPTION
…hould not be set as a route prefix.