### PR TITLE
Some minor fixes which already waited for too long

### DIFF
--- a/packages/furo-data/src/furo-data-object.js
+++ b/packages/furo-data/src/furo-data-object.js
@@ -141,13 +141,23 @@ export class FuroDataObject extends LitElement {
   }
 
   /**
+   * @event init-completed
+   * Fired when the object init was done
+   *
+   * **detail payload:** A EntityNode object
+   *
+   * **bubbles**
+   */
+  /**
    * Sets the model to an initial state according to the given type.
+   *
+   * fires *init-completed*
    *
    * To reset changed data to the last injected state, please use reset();
    */
   init() {
     this.data.init();
-    const customEvent = new Event('object-ready', { composed: true, bubbles: true });
+    const customEvent = new Event('init-completed', { composed: true, bubbles: true });
     customEvent.detail = this.data;
     setTimeout(() => {
       this.dispatchEvent(customEvent);

--- a/packages/furo-data/src/furo-data-object.js
+++ b/packages/furo-data/src/furo-data-object.js
@@ -87,7 +87,6 @@ export class FuroDataObject extends LitElement {
    * Clears all errors on children without any validation!
    */
   clearAllErrors() {
-    // broadcast validation
     this.data.clearAllErrors();
   }
 

--- a/packages/furo-data/src/furo-data-object.js
+++ b/packages/furo-data/src/furo-data-object.js
@@ -84,6 +84,14 @@ export class FuroDataObject extends LitElement {
   }
 
   /**
+   * Clears all errors on children without any validation!
+   */
+  clearAllErrors() {
+    // broadcast validation
+    this.data.clearAllErrors();
+  }
+
+  /**
    * Triggers the validation of all fields in the data object.
    *
    * Use this before you submit some data to a server.

--- a/packages/furo-data/src/furo-entity-agent.js
+++ b/packages/furo-data/src/furo-entity-agent.js
@@ -503,7 +503,7 @@ class FuroEntityAgent extends FBP(LitElement) {
     let failed = e => {
       // append error to the _requestDataObject (set the fields invalid)
       const err = e.detail;
-      if (err.error && err.details) {
+      if ((err.message || err.code) && err.details) {
         err.details.forEach(errorSet => {
           if (errorSet.field_violations) {
             const fieldViolations = JSON.parse(JSON.stringify(errorSet.field_violations));

--- a/packages/furo-data/src/lib/DataObject.js
+++ b/packages/furo-data/src/lib/DataObject.js
@@ -60,8 +60,10 @@ export class DataObject extends EventTreeNode {
    * clears all errors on every fieldnode
    */
   clearAllErrors() {
-    // broadcast clearAllErrors request to all fields
-    this.broadcastEvent(new NodeEvent('clear-all-errors-requested', this));
+    if (!this._pristine) {
+      // broadcast clearAllErrors request to all fields
+      this.broadcastEvent(new NodeEvent('clear-all-errors-requested', this));
+    }
   }
 
   /**

--- a/packages/furo-data/src/lib/DataObject.js
+++ b/packages/furo-data/src/lib/DataObject.js
@@ -57,6 +57,14 @@ export class DataObject extends EventTreeNode {
   }
 
   /**
+   * clears all errors on every fieldnode
+   */
+  clearAllErrors() {
+    // broadcast clearAllErrors request to all fields
+    this.broadcastEvent(new NodeEvent('clear-all-errors-requested', this));
+  }
+
+  /**
    * Injecten eines raw models wie bspw body oder entity einer collection
    * @param rawEntity
    */

--- a/packages/furo-data/src/lib/FieldNode.js
+++ b/packages/furo-data/src/lib/FieldNode.js
@@ -132,6 +132,12 @@ export class FieldNode extends EventTreeNode {
       this._checkConstraints();
     });
 
+    // clear the errors
+    this.addEventListener('clear-all-errors-requested', () => {
+      this._clearInvalidity();
+    });
+
+
     this.addEventListener('parent-readonly-meta-set', () => {
       // check parent readonly meta and inherit if true
       if (

--- a/packages/furo-data/src/lib/FieldNode.js
+++ b/packages/furo-data/src/lib/FieldNode.js
@@ -137,7 +137,6 @@ export class FieldNode extends EventTreeNode {
       this._clearInvalidity();
     });
 
-
     this.addEventListener('parent-readonly-meta-set', () => {
       // check parent readonly meta and inherit if true
       if (

--- a/packages/furo-data/src/lib/UniversalFieldNodeBinder.js
+++ b/packages/furo-data/src/lib/UniversalFieldNodeBinder.js
@@ -438,6 +438,7 @@ export class UniversalFieldNodeBinder {
       return 'complex';
     }
 
+    // eslint-disable-next-line no-console
     console.warn('fieldNode is not defined, please check against the spec', field);
     return undefined;
   }

--- a/packages/furo-notification/src/furo-banner.js
+++ b/packages/furo-notification/src/furo-banner.js
@@ -178,22 +178,28 @@ class FuroBanner extends LitElement {
     // fallback, if no localized message was given
     this.setText(status.message);
     // log developper message
-    if (status.details && status.details.length > 0) {
-      this.multilineText = [];
-      // show localized messages first
-      this.multilineText = this.multilineText.concat(
-        status.details
-          .filter(det => det['@type'].includes('LocalizedMessage'))
-          .map(det => det.message),
-      );
-      // list descriptions of badRequest errors
-      this.multilineText = this.multilineText.concat(
-        status.details
-          .filter(det => det['@type'].includes('google.rpc.BadRequest'))
-          .map(det => det.field_violations.map(violation => violation.description))[0],
-      );
-      // todo: implement the other error types from https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
-      // Help, RequestInfo, ResourceInfo, PreconditionFailure
+    if (status.details) {
+      if (status.details.length > 0) {
+        this.multilineText = [];
+        // show localized messages first
+        this.multilineText = this.multilineText.concat(
+          status.details
+            .filter(det => det['@type'].includes('LocalizedMessage'))
+            .map(det => det.message),
+        );
+        // list descriptions of badRequest errors
+        this.multilineText = this.multilineText.concat(
+          status.details
+            .filter(det => det['@type'].includes('google.rpc.BadRequest'))
+            .map(det => {
+              if (det.field_violations){ return det.field_violations.map(violation => violation.description);}else{
+                return [""];
+              }
+            })[0],
+        );
+        // todo: implement the other error types from https://github.com/googleapis/googleapis/blob/master/google/rpc/error_details.proto
+        // Help, RequestInfo, ResourceInfo, PreconditionFailure
+      }
     }
 
     this.show(status);

--- a/packages/furo-route/src/furo-qp-changer.js
+++ b/packages/furo-route/src/furo-qp-changer.js
@@ -13,6 +13,17 @@ import { FBP } from '@furo/fbp';
  * @appliesMixin FBP
  */
 class FuroQpChanger extends FBP(LitElement) {
+
+
+  static get properties() {
+    return {
+      /**
+       * Comma separated list of qp to clear if they are not explizitly set with `setQp`
+       */
+      clear: { type: String },
+    };
+  }
+
   setQp(newQP) {
     // read current qp and update incomming qp
 
@@ -25,6 +36,13 @@ class FuroQpChanger extends FBP(LitElement) {
         queryObject[p[0]] = p[1];
       });
     }
+
+    // clear qps
+    this.clear.split(",").forEach((ps)=>{
+      delete queryObject[ps.trim()]
+    })
+
+    // append qps
     // eslint-disable-next-line guard-for-in,no-restricted-syntax
     for (const param in newQP) {
       queryObject[param] = newQP[param];

--- a/packages/furo-route/src/furo-qp-changer.js
+++ b/packages/furo-route/src/furo-qp-changer.js
@@ -13,8 +13,6 @@ import { FBP } from '@furo/fbp';
  * @appliesMixin FBP
  */
 class FuroQpChanger extends FBP(LitElement) {
-
-
   static get properties() {
     return {
       /**
@@ -38,9 +36,11 @@ class FuroQpChanger extends FBP(LitElement) {
     }
 
     // clear qps
-    this.clear.split(",").forEach((ps)=>{
-      delete queryObject[ps.trim()]
-    })
+    if (this.clear) {
+      this.clear.split(',').forEach(ps => {
+        delete queryObject[ps.trim()];
+      });
+    }
 
     // append qps
     // eslint-disable-next-line guard-for-in,no-restricted-syntax


### PR DESCRIPTION

- clear all errors on new data (also exposed as clear-all-errors on data-object)
- feat: qp-changer with clearable qps
- fix: banner should also work if no field violation was set by server
- fix: entity-agent should handle errors from gateway v2 
