### PR TITLE
fix: add prefix for the links in the meta of the reference types

### DIFF
--- a/packages/furo-framework/src/system.js
+++ b/packages/furo-framework/src/system.js
@@ -111,9 +111,14 @@ export class Init {
           Env.api.specs[t].fields[field].meta &&
           Env.api.specs[t].fields[field].meta.default
         ) {
+          if (typeof Env.api.specs[t].fields[field].meta.default === 'string') {
+            Env.api.specs[t].fields[field].meta.default = JSON.parse(
+              Env.api.specs[t].fields[field].meta.default,
+            );
+          }
           const deeplink = Env.api.specs[t].fields[field].meta.default.link;
           if (deeplink.href && deeplink.href.length && deeplink.href.startsWith('/')) {
-            deeplink.href = Env.api.prefix + deeplink.href;
+            Env.api.specs[t].fields[field].meta.default.link.href = Env.api.prefix + deeplink.href;
           }
         }
       }


### PR DESCRIPTION
add tehe prefix for the links in the meta of the reference types
the spectools generates the enviroment with links in meta in json string : {"link":".."} . therefor it needs to be converted in obj before adding e.g. 'api' prefix.
we must also the the spectools to findout why the link for reference type is not converted to object. 