### PR TITLE
Fix/google wrapper types

### DIFF
--- a/mockdata/tests/universalfieldnodebinder/fat-universal-demo.json
+++ b/mockdata/tests/universalfieldnodebinder/fat-universal-demo.json
@@ -2,9 +2,7 @@
   "data": {
     "id": "1",
     "scalar_string": "this is a scalar string",
-    "wrapper_string": {
-      "value": "this is a google wrapper string"
-    },
+    "wrapper_string": "this is a google wrapper string",
     "fat_string": {
       "value": "this is a demo fat string",
       "labels": ["required", "condensed"],
@@ -18,9 +16,7 @@
       }
     },
     "scalar_int32": 14,
-    "wrapper_int32": {
-      "value": 14
-    },
+    "wrapper_int32":14,
     "fat_int32": {
       "value": 14,
       "value-state": "Information"
@@ -29,9 +25,7 @@
       "value": true,
       "value-state": "Information"
     },
-    "wrapper_bool": {
-      "value": true
-    }
+    "wrapper_bool":true
   },
   "links": [],
   "meta": {

--- a/mockdata/tests/universalfieldnodebinder/fat-universal-unset-label.json
+++ b/mockdata/tests/universalfieldnodebinder/fat-universal-unset-label.json
@@ -2,9 +2,7 @@
   "data": {
     "id": "1",
     "scalar_string": "this is a scalar string",
-    "wrapper_string": {
-      "value": "this is a google wrapper string"
-    },
+    "wrapper_string": "this is a google wrapper string",
     "fat_string": {
       "value": "this is a furo fat string",
       "labels": ["after"],
@@ -14,9 +12,7 @@
       }
     },
     "scalar_int32": 14,
-    "wrapper_int32": {
-      "value": 14
-    },
+    "wrapper_int32": 14,
     "fat_int32": {
       "value": 14,
       "value-state": "Information"
@@ -25,9 +21,7 @@
       "value": true,
       "value-state": "Information"
     },
-    "wrapper_bool": {
-      "value": true
-    }
+    "wrapper_bool": true
   },
   "links": [],
   "meta": {}

--- a/mockdata/tests/universalfieldnodebinder/fat-universal-with-meta.json
+++ b/mockdata/tests/universalfieldnodebinder/fat-universal-with-meta.json
@@ -2,9 +2,7 @@
   "data": {
     "id": "1",
     "scalar_string": "this is a scalar string",
-    "wrapper_string": {
-      "value": "this is a google wrapper string"
-    },
+    "wrapper_string": "this is a google wrapper string",
     "fat_string": {
       "value": "this is a furo fat string",
       "labels": ["condensed"],
@@ -15,9 +13,7 @@
       }
     },
     "scalar_int32": 14,
-    "wrapper_int32": {
-      "value": 14
-    },
+    "wrapper_int32": 14,
     "fat_int32": {
       "value": 14,
       "labels": "",
@@ -29,9 +25,7 @@
       "value": true,
       "value-state": "Information"
     },
-    "wrapper_bool": {
-      "value": true
-    }
+    "wrapper_bool": true
   },
   "links": [],
   "meta": {

--- a/mockdata/tests/universalfieldnodebinder/fat-universal.json
+++ b/mockdata/tests/universalfieldnodebinder/fat-universal.json
@@ -2,9 +2,7 @@
   "data": {
     "id": "1",
     "scalar_string": "this is a scalar string",
-    "wrapper_string": {
-      "value": "this is a google wrapper string"
-    },
+    "wrapper_string": "this is a google wrapper string",
     "fat_string": {
       "value": "this is a furo fat string",
       "labels": ["before"],
@@ -19,9 +17,7 @@
       }
     },
     "scalar_int32": 14,
-    "wrapper_int32": {
-      "value": 14
-    },
+    "wrapper_int32": 14,
     "fat_int32": {
       "value": 14
     },
@@ -32,9 +28,7 @@
         "label": "override"
       }
     },
-    "wrapper_bool": {
-      "value": true
-    },
+    "wrapper_bool":  true,
     "fat_string_repeated": [
       {
         "value": "this is a furo fat string",

--- a/packages/furo-app/src/furo-app-drawer.js
+++ b/packages/furo-app/src/furo-app-drawer.js
@@ -440,6 +440,7 @@ class FuroAppDrawer extends FBP(LitElement) {
     return x;
   }
 
+
   // eslint-disable-next-line class-methods-use-this
   _getScreenY(e) {
     let y;

--- a/packages/furo-data/src/lib/FieldNode.js
+++ b/packages/furo-data/src/lib/FieldNode.js
@@ -77,7 +77,21 @@ export class FieldNode extends EventTreeNode {
     this._validationDisabled = this.__parentNode._validationDisabled;
 
     // Build custom type if a spec exists
-    if (this.__specdefinitions[this._spec.type] !== undefined) {
+    if (this.__specdefinitions[this._spec.type] !== undefined &&
+      this._spec.type !== "google.protobuf.StringValue" &&
+      this._spec.type !== "google.protobuf.BoolValue" &&
+      this._spec.type !== "google.protobuf.FloatValue" &&
+      this._spec.type !== "google.protobuf.Int32Value" &&
+      this._spec.type !== "google.protobuf.Int64Value" &&
+      this._spec.type !== "google.protobuf.DoubleValue" &&
+      this._spec.type !== "google.protobuf.Duration" &&
+      this._spec.type !== "google.protobuf.Timestamp" &&
+      this._spec.type !== "google.protobuf.FieldMask" &&
+      this._spec.type !== "google.protobuf.BytesValue" &&
+      this._spec.type !== "google.protobuf.UInt32Value" &&
+      this._spec.type !== "google.protobuf.UInt64Value"
+    ) {
+
       // check for recursion
 
       if (!this.__parentNode._hasAncestorOfType(this._spec.type)) {

--- a/packages/furo-data/src/lib/FieldNode.js
+++ b/packages/furo-data/src/lib/FieldNode.js
@@ -77,21 +77,21 @@ export class FieldNode extends EventTreeNode {
     this._validationDisabled = this.__parentNode._validationDisabled;
 
     // Build custom type if a spec exists
-    if (this.__specdefinitions[this._spec.type] !== undefined &&
-      this._spec.type !== "google.protobuf.StringValue" &&
-      this._spec.type !== "google.protobuf.BoolValue" &&
-      this._spec.type !== "google.protobuf.FloatValue" &&
-      this._spec.type !== "google.protobuf.Int32Value" &&
-      this._spec.type !== "google.protobuf.Int64Value" &&
-      this._spec.type !== "google.protobuf.DoubleValue" &&
-      this._spec.type !== "google.protobuf.Duration" &&
-      this._spec.type !== "google.protobuf.Timestamp" &&
-      this._spec.type !== "google.protobuf.FieldMask" &&
-      this._spec.type !== "google.protobuf.BytesValue" &&
-      this._spec.type !== "google.protobuf.UInt32Value" &&
-      this._spec.type !== "google.protobuf.UInt64Value"
+    if (
+      this.__specdefinitions[this._spec.type] !== undefined &&
+      this._spec.type !== 'google.protobuf.StringValue' &&
+      this._spec.type !== 'google.protobuf.BoolValue' &&
+      this._spec.type !== 'google.protobuf.FloatValue' &&
+      this._spec.type !== 'google.protobuf.Int32Value' &&
+      this._spec.type !== 'google.protobuf.Int64Value' &&
+      this._spec.type !== 'google.protobuf.DoubleValue' &&
+      this._spec.type !== 'google.protobuf.Duration' &&
+      this._spec.type !== 'google.protobuf.Timestamp' &&
+      this._spec.type !== 'google.protobuf.FieldMask' &&
+      this._spec.type !== 'google.protobuf.BytesValue' &&
+      this._spec.type !== 'google.protobuf.UInt32Value' &&
+      this._spec.type !== 'google.protobuf.UInt64Value'
     ) {
-
       // check for recursion
 
       if (!this.__parentNode._hasAncestorOfType(this._spec.type)) {

--- a/packages/furo-data/test/UniversalFieldNodeBinder.test.js
+++ b/packages/furo-data/test/UniversalFieldNodeBinder.test.js
@@ -49,7 +49,7 @@ describe('UniversalFieldNodeBinder.test', () => {
 
   it('should detect if google wrapper type was given', done => {
     pseudocomponent.binder.bindField(dataobj.data.data.wrapper_string);
-    assert.equal(pseudocomponent.binder.fieldFormat, 'wrapper');
+    assert.equal(pseudocomponent.binder.fieldFormat, 'scalar');
     done();
   });
 
@@ -289,7 +289,7 @@ describe('UniversalFieldNodeBinder.test', () => {
 
         pseudocomponent.binder.fieldValue = 'm2';
         assert.equal(pseudocomponent.value, 'm2');
-        assert.equal(pseudocomponent.binder.fieldNode.value._value, 'm2');
+        assert.equal(pseudocomponent.binder.fieldNode._value, 'm2');
         done();
       },
       { once: true },
@@ -392,22 +392,26 @@ describe('UniversalFieldNodeBinder.test', () => {
       maxlength: 'maxLength',
       minlength: 'minLength',
     };
-    dataobj.addEventListener('data-injected', () => {
-      pseudocomponent.binder.bindField(dataobj.data.data.scalar_string);
-      assert.equal(pseudocomponent.value, pseudocomponent.binder._fieldValue);
-      pseudocomponent.binder.setAttribute('minlength', 'small');
-      pseudocomponent.binder.setAttribute('value-state', 'Error');
-      pseudocomponent.binder.setAttribute('label', 'Error');
-      assert.equal(pseudocomponent.label, undefined);
-      assert.equal(pseudocomponent.valueState, 'Error');
-      assert.equal(pseudocomponent.minLength, 'small');
-      pseudocomponent.binder.removeAttribute('value-state');
-      pseudocomponent.binder.removeAttribute('label');
-      assert.equal(pseudocomponent.valueState, null);
-      assert.equal(pseudocomponent.label, undefined);
+    dataobj.addEventListener(
+      'data-injected',
+      () => {
+        pseudocomponent.binder.bindField(dataobj.data.data.scalar_string);
+        assert.equal(pseudocomponent.value, pseudocomponent.binder._fieldValue);
+        pseudocomponent.binder.setAttribute('minlength', 'small');
+        pseudocomponent.binder.setAttribute('value-state', 'Error');
+        pseudocomponent.binder.setAttribute('label', 'Error');
+        assert.equal(pseudocomponent.label, undefined);
+        assert.equal(pseudocomponent.valueState, 'Error');
+        assert.equal(pseudocomponent.minLength, 'small');
+        pseudocomponent.binder.removeAttribute('value-state');
+        pseudocomponent.binder.removeAttribute('label');
+        assert.equal(pseudocomponent.valueState, null);
+        assert.equal(pseudocomponent.label, undefined);
 
-      done();
-    });
+        done();
+      },
+      { once: true },
+    );
     fetchData('/mockdata/tests/universalfieldnodebinder/fat-universal.json');
   });
 


### PR DESCRIPTION
The google wrapper types are delivered as plain json values and expected as plain json values. So handling them as scalar on the client side saves us a lot of transformation work. Even furo can handle the proto structure with ease.