### PR TITLE
fix: When a repeated node is added, because of the meta

### DIFF
--- a/packages/furo-data/src/lib/RepeaterNode.js
+++ b/packages/furo-data/src/lib/RepeaterNode.js
@@ -322,6 +322,13 @@ export class RepeaterNode extends EventTreeNode {
 
   _addSilent() {
     const fieldNode = new FieldNode(this, this._spec, this._name);
+    /**
+     * by adding a repeated node, which is itself repeated, the child node can not be repeated
+     * So set this to false in the meta should be correct
+     *
+     */
+    fieldNode._meta.repeated = false;
+
     // if this field has disabled Validation, pass to new attributes. Because they do not have to validate too.
     if (this._validationDisabled || this.__parentNode._validationDisabled) {
       fieldNode._validationDisabled = true;


### PR DESCRIPTION
When a repeated node is added, because the meta says that it is a RepeaterNode the children should not be repeated.

**Solution:** Set the _meta.repeated on children to false.

Otherwise the dropdowns from furo-data-input think they should be repeated. What is definitive not a correct information.