### PR TITLE
feat: default set on furo.Link types will prefix with api-base-url 

### DIFF
--- a/packages/furo-data/src/lib/RepeaterNode.js
+++ b/packages/furo-data/src/lib/RepeaterNode.js
@@ -349,11 +349,14 @@ export class RepeaterNode extends EventTreeNode {
     this._isValid = false;
     const path = error.field.split('.');
     if (path.length > 0) {
-      // rest wieder in error reinwerfen
+      // den rest wieder in error reinwerfen
       // eslint-disable-next-line no-param-reassign
       error.field = path.slice(1).join('.');
     }
-    this.repeats[path[0]]._setInvalid(error);
+
+    if (this.repeats[path[0]]) {
+      this.repeats[path[0]]._setInvalid(error);
+    }
   }
 
   add(data) {

--- a/packages/furo-framework/src/system.js
+++ b/packages/furo-framework/src/system.js
@@ -128,6 +128,24 @@ export class Init {
             Env.api.specs[t].fields[field].meta.default.link.href = Env.api.prefix + deeplink.href;
           }
         }
+
+        // Apply the prefix for the default links in furo.Link types
+        if (
+          Env.api.specs[t].fields[field].type === 'furo.Link' &&
+          Env.api.specs[t].fields[field].meta &&
+          Env.api.specs[t].fields[field].meta.default
+        ) {
+
+
+          Env.api.specs[t].fields[field].meta.default = JSON.parse(
+            Env.api.specs[t].fields[field].meta.default,
+          );
+          // Apply only when the prefix is not hard coded in the specs
+          const deeplink = Env.api.specs[t].fields[field].meta.default;
+          if (deeplink && deeplink.href && deeplink.href.length && deeplink.href.startsWith('/') && !deeplink.href.startsWith(`${Env.api.prefix }/`) ) {
+            Env.api.specs[t].fields[field].meta.default.href = Env.api.prefix + deeplink.href;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Only when it is not hard coded in the specs.

/api/xxx will not become /api/api/xxx

maybe we should add this feature to the other prefixer too?