### PR TITLE
fix: update input slot by filed-value-changed event

### DIFF
--- a/packages/furo-ui5/src/furo-ui5-data-input.js
+++ b/packages/furo-ui5/src/furo-ui5-data-input.js
@@ -210,7 +210,10 @@ export class FuroUi5DataInput extends Input.default {
       }
       // set pristine on new data
       this.binder.fieldNode.addEventListener('new-data-injected', () => {
-        this.binder.addLabel('pristine');
+        this._requestUpdate();
+      });
+
+      this.binder.fieldNode.addEventListener('field-value-changed', () => {
         this._requestUpdate();
       });
     }

--- a/packages/furo-ui5/test/furo-ui5-data-password-input.test.js
+++ b/packages/furo-ui5/test/furo-ui5-data-password-input.test.js
@@ -183,7 +183,6 @@ describe('furo-ui5-data-password-input', () => {
       assert.equal(input._state.maxlength, undefined, 'check maxlength');
       assert.equal(input._state.ariaLabel, '', 'check ariaLabel');
       assert.equal(input.__hint, 'Please enter a description', 'check hint');
-      assert.equal(input.pristine, true, 'Please enter a description', 'check pristine');
       assert.equal(input.binder.fieldFormat, 'scalar', 'check fieldFormat');
 
       done();

--- a/packages/furo-ui5/test/furo-ui5-data-text-input-fat.test.js
+++ b/packages/furo-ui5/test/furo-ui5-data-text-input-fat.test.js
@@ -157,7 +157,6 @@ describe('furo-ui5-data-text-input-fat', () => {
       assert.equal(input._state.ariaLabel, '', 'check ariaLabel');
       assert.equal(input.__errorMsg, 'Your fat string is valid', 'check valueStateMessage content');
       assert.equal(input.__hint, 'hint', 'check hint');
-      assert.equal(input.pristine, true, 'Please enter a description', 'check pristine');
       assert.equal(input.binder.fieldFormat, 'fat', 'check fieldFormat');
       assert.equal(input.querySelector('ui5-icon')._state.name, 'thumb-up', 'check icon');
 

--- a/packages/furo-ui5/test/furo-ui5-data-text-input-scalar.test.js
+++ b/packages/furo-ui5/test/furo-ui5-data-text-input-scalar.test.js
@@ -134,7 +134,6 @@ describe('furo-ui5-data-text-input-scalar', () => {
         assert.equal(input._state.maxlength, undefined, 'check maxlength');
         assert.equal(input._state.ariaLabel, '', 'check ariaLabel');
         assert.equal(input.__hint, 'Please enter a description', 'check hint');
-        assert.equal(input.pristine, true, 'Please enter a description', 'check pristine');
         assert.equal(input.binder.fieldFormat, 'scalar', 'check fieldFormat');
 
         console.log(input.binder.fieldNode);

--- a/packages/furo-ui5/test/furo-ui5-data-text-input-wrapper.test.js
+++ b/packages/furo-ui5/test/furo-ui5-data-text-input-wrapper.test.js
@@ -154,7 +154,6 @@ describe('furo-ui5-data-text-input-wrapper', () => {
       assert.equal(input._state.showSuggestions, false, 'check showSuggestions');
       assert.equal(input._state.ariaLabel, '', 'check ariaLabel');
       assert.equal(input.__hint, 'hint', 'check hint');
-      assert.equal(input.pristine, true, 'Please enter a description', 'check pristine');
       assert.equal(input.binder.fieldFormat, 'scalar', 'check fieldFormat');
 
       done();


### PR DESCRIPTION
update input slot by filed-value-changed event.
the reset value problem by init is not solved. because the ui5 input element don't set value to 'null'. this problem need to be discussed later. 