### PR TITLE
fix: external links should not notify location change in the caller

### DIFF
--- a/packages/furo-route/src/furo-app-flow-router.js
+++ b/packages/furo-route/src/furo-app-flow-router.js
@@ -61,6 +61,7 @@ class FuroAppFlowRouter extends FBP(LitElement) {
        *    ['view-main', 'button-tap', 'detail-view',  'task => id],
        *    ["*", "search", "EXTERNAL_LINK: https://google.com/"],
        *    ["*", "searchInNewWindow", "EXTERNAL_LINK_BLANK: https://google.com/"]
+       *    ["*", "searchInNewWindow", "EXTERNAL_LINK_BLANK:", *]
        *  ]
        *  ```
        *
@@ -149,13 +150,26 @@ class FuroAppFlowRouter extends FBP(LitElement) {
       if (selection.target === 'HISTORY-BACK') {
         this.back();
       } else {
-        if (selection.target.startsWith('EXTERNAL_LINK:')) {
-          window.location.href = selection.target.substr(14).trim();
-        } else if (selection.target.startsWith('EXTERNAL_LINK_BLANK:')) {
-          window.open(selection.target.substr(20).trim());
-        } else {
-          window.history.pushState({}, '', prefix + selection.target + search);
+        const sa = [];
+        // eslint-disable-next-line guard-for-in,no-restricted-syntax
+        for (const k in flowEvent.data) {
+          sa.push(flowEvent.data[k]);
         }
+
+        if (selection.target.startsWith('EXTERNAL_LINK:')) {
+          // eslint-disable-next-line babel/no-unused-expressions
+          sa.length
+            ? window.open(sa.join(''))
+            : (window.location.href = selection.target.substr(14).trim());
+          return true;
+        }
+        if (selection.target.startsWith('EXTERNAL_LINK_BLANK:')) {
+          // eslint-disable-next-line babel/no-unused-expressions
+          sa.length ? window.open(sa.join('')) : window.open(selection.target.substr(20).trim());
+          return true;
+        }
+
+        window.history.pushState({}, '', prefix + selection.target + search);
 
         /**
          * Internal notyfication

--- a/packages/furo-route/test/furo-location-updater-hash.test.js
+++ b/packages/furo-route/test/furo-location-updater-hash.test.js
@@ -20,7 +20,7 @@ describe('furo-location-updater-hash', () => {
     `);
     await testbind.updateComplete;
     host = testbind._host;
-    [, element,furoLocation] = testbind.parentNode.children;
+    [, element, furoLocation] = testbind.parentNode.children;
     await host.updateComplete;
     await element.updateComplete;
     await furoLocation.updateComplete;
@@ -41,29 +41,24 @@ describe('furo-location-updater-hash', () => {
     element.setHash({ a: 3 });
   });
 
-
-
-
   it('should add additional hashes on changed Hash', done => {
     element.setHash({ a: 4444 });
     element.setHash({ b: 3333 });
     element.setHash({ xb: 3333 });
 
-    assert.equal(window.location.hash , '#a=4444&b=3333&xb=3333');
+    assert.equal(window.location.hash, '#a=4444&b=3333&xb=3333');
 
     done();
   });
-
-
 
   it('should clear other hash', done => {
     // attention XB comes from test before
     element.setHash({ a: 4444 });
     element.setHash({ b: 457 });
-    assert.equal(window.location.hash , '#a=4444&b=457&xb=3333');
+    assert.equal(window.location.hash, '#a=4444&b=457&xb=3333');
     element.setAttribute('clear-hash', 'xb,a,c');
     element.setHash({ c: 333 });
-    assert.equal(window.location.hash , '#b=457&c=333');
+    assert.equal(window.location.hash, '#b=457&c=333');
     done();
   });
 });

--- a/packages/furo-route/test/furo-location-updater-qp.test.js
+++ b/packages/furo-route/test/furo-location-updater-qp.test.js
@@ -20,7 +20,7 @@ describe('furo-location-updater-qps', () => {
     `);
     await testbind.updateComplete;
     host = testbind._host;
-    [, element,furoLocation] = testbind.parentNode.children;
+    [, element, furoLocation] = testbind.parentNode.children;
     await host.updateComplete;
     await element.updateComplete;
     await furoLocation.updateComplete;
@@ -32,7 +32,6 @@ describe('furo-location-updater-qps', () => {
     done();
   });
 
-
   it('should dispatch a location-changed event on changed QP', done => {
     furoLocation.addEventListener('location-changed', e => {
       assert.equal(e.type, 'location-changed');
@@ -41,9 +40,7 @@ describe('furo-location-updater-qps', () => {
     element.setQp({ j: 8 });
   });
 
-
   it('should add additional qps', done => {
-
     element.setQp({ a: 4444 });
     element.setQp({ b: 457 });
     // attention: the j comes from test before
@@ -62,5 +59,4 @@ describe('furo-location-updater-qps', () => {
     assert.equal(window.location.search.slice(1), 'b=457&c=333');
     done();
   });
-
 });


### PR DESCRIPTION
If we use the external_link pattern the internal location change notification should not be called.