### PR TITLE
RepeaterNode with fresh list on every update

### DIFF
--- a/packages/furo-data/src/lib/DataObject.js
+++ b/packages/furo-data/src/lib/DataObject.js
@@ -189,7 +189,13 @@ export class DataObject extends EventTreeNode {
       } else if (fieldNode._isRepeater) {
         // const initialSize = fieldNode.repeats.length;
 
-        // fieldNode.removeAllChildren();
+        fieldNode.dispatchNodeEvent(
+          new NodeEvent('before-repeated-field-changed', fieldNode, false)
+        );
+
+        if(fieldNode.clearListOnNewData){
+          fieldNode.removeAllChildren();
+        }
 
         // update records
         data[fieldName].forEach((repdata, i) => {

--- a/packages/furo-data/src/lib/RepeaterNode.js
+++ b/packages/furo-data/src/lib/RepeaterNode.js
@@ -168,9 +168,6 @@ export class RepeaterNode extends EventTreeNode {
 
     if (Array.isArray(val)) {
 
-      this.__parentNode.dispatchNodeEvent(
-        new NodeEvent('before-repeated-field-changed', this, false),
-      );
       this.dispatchNodeEvent(new NodeEvent('before-repeated-field-changed', this, false));
 
       if(this.clearListOnNewData){

--- a/packages/furo-data/src/lib/RepeaterNode.js
+++ b/packages/furo-data/src/lib/RepeaterNode.js
@@ -11,6 +11,12 @@ export class RepeaterNode extends EventTreeNode {
     this._spec = spec;
     this._name = fieldName;
 
+    /**
+     * Set this to true to clear the list on new data instead updating the current list.
+     * @type {boolean}
+     */
+    this.clearListOnNewData = false;
+
     if (this._spec.meta) {
       this._meta = JSON.parse(JSON.stringify(this._spec.meta));
     } else {
@@ -158,14 +164,17 @@ export class RepeaterNode extends EventTreeNode {
   }
 
   set _value(val) {
+
+
     if (Array.isArray(val)) {
-      // remove all items if type is furo.Property
-      if (this._spec.type === 'furo.Property') {
+
+      this.__parentNode.dispatchNodeEvent(
+        new NodeEvent('before-repeated-field-changed', this, false),
+      );
+      this.dispatchNodeEvent(new NodeEvent('before-repeated-field-changed', this, false));
+
+      if(this.clearListOnNewData){
         this.removeAllChildren();
-        this.__parentNode.dispatchNodeEvent(
-          new NodeEvent('this-repeated-field-changed', this, false),
-        );
-        this.dispatchNodeEvent(new NodeEvent('this-repeated-field-changed', this, false));
       }
 
       val.forEach((repdata, i) => {

--- a/packages/furo-ui5/src/furo-ui5-data-property.js
+++ b/packages/furo-ui5/src/furo-ui5-data-property.js
@@ -102,6 +102,11 @@ class FuroUi5DataProperty extends FBP(LitElement) {
     this.field = propertyField;
 
     if (propertyField._isRepeater) {
+
+      // we want a fresh list on every update of the list, because the types and order of the list items can change
+      // eslint-disable-next-line no-param-reassign
+      propertyField.clearListOnNewData = true;
+
       // add flow repeat to parent and inject on repeated changes
       // repeated
       const r = document.createElement('flow-repeat');


### PR DESCRIPTION
Added the option **clearListOnNewData** on `RepeaterNode` to  clear the list on new data instead updating the current list.

Added new event **before-repeated-field-changed** which is triggered before a repeater node gets updated

