### PR TITLE
fix: headers should keep spaces

### DIFF
--- a/packages/furo-ui5/src/furo-ui5-data-table.js
+++ b/packages/furo-ui5/src/furo-ui5-data-table.js
@@ -213,7 +213,7 @@ class FuroUi5DataTable extends FBP(LitElement) {
    */
   _init() {
     const cols = this.columns.replace(/ /g, '').split(',');
-    this._headers = this.headers.replace(/ /g, '').split(',');
+    this._headers = this.headers.split(',');
     this._popinFields = this.popinFields.replace(/ /g, '').split(',');
 
     this._colStyle = [];


### PR DESCRIPTION
If you use the attribute _headers_  to describe the table columns, the spaces in the words must be retained.