### PR TITLE
Bugfix/timestamp rfc3339

### DIFF
--- a/mockdata/experiments/1/get.json
+++ b/mockdata/experiments/1/get.json
@@ -16,7 +16,10 @@
       "month": 12,
       "year": 2020
     },
-    "google_timestamp": "1970-11-01T02:46:40.000000022Z",
+    "google_timestamp": {
+      "seconds": 1621577867,
+      "nanos": 0
+    },
     "furo_data_range_input": 31,
     "furo_data_bool_icon": false,
     "the_any_type": {

--- a/packages/furo-ui5/demos/helper/form-section-four.js
+++ b/packages/furo-ui5/demos/helper/form-section-four.js
@@ -92,6 +92,11 @@ class FormSectionFour extends FBP(LitElement) {
           ƒ-.disabled="--disable"
           ƒ-bind-data="--entity(*.data.furo_data_date_input_google)"
         ></furo-ui5-data-display>
+
+        <furo-ui5-data-display
+          ƒ-.disabled="--disable"
+          ƒ-bind-data="--entity(*.data.google_timestamp)"
+        ></furo-ui5-data-display>
       </furo-form-layouter>
     `;
   }

--- a/packages/furo-ui5/src/furo-ui5-data-date-time-picker.js
+++ b/packages/furo-ui5/src/furo-ui5-data-date-time-picker.js
@@ -111,7 +111,7 @@ export class FuroUi5DataDatePicker extends FieldNodeAdapter(DateTimePicker.defau
 
         case 'google.protobuf.Timestamp':
           if (e.value !== '' && e.valid) {
-            const TS = {seconds:0, nanos: 0}
+            const TS = { seconds: 0, nanos: 0 };
             TS.seconds = this.dateValue / 1000;
             TS.nanos = (this.dateValue % 1000) * 1e6;
             this.setFnaFieldValue(TS);
@@ -158,8 +158,10 @@ export class FuroUi5DataDatePicker extends FieldNodeAdapter(DateTimePicker.defau
         this.value = this.formatValue(new Date(value * 1000));
         break;
       case 'google.protobuf.Timestamp':
-        if (value && value.seconds > 0){
-          this.value = this.formatValue(new Date(value.seconds * 1000 + Math.round(value.nanos / MS_TO_NANOS)));
+        if (value && value.seconds > 0) {
+          this.value = this.formatValue(
+            new Date(value.seconds * 1000 + Math.round(value.nanos / MS_TO_NANOS)),
+          );
         }
         break;
 

--- a/packages/furo-ui5/src/furo-ui5-data-date-time-picker.js
+++ b/packages/furo-ui5/src/furo-ui5-data-date-time-picker.js
@@ -111,7 +111,10 @@ export class FuroUi5DataDatePicker extends FieldNodeAdapter(DateTimePicker.defau
 
         case 'google.protobuf.Timestamp':
           if (e.value !== '' && e.valid) {
-            this.setFnaFieldValue(this.dateValue.toISOString());
+            const TS = {seconds:0, nanos: 0}
+            TS.seconds = this.dateValue / 1000;
+            TS.nanos = (this.dateValue % 1000) * 1e6;
+            this.setFnaFieldValue(TS);
           } else {
             this.setFnaFieldValue(null);
           }
@@ -147,12 +150,19 @@ export class FuroUi5DataDatePicker extends FieldNodeAdapter(DateTimePicker.defau
 
   onFnaFieldValueChanged(value) {
     const type = this.getDataType();
+    const MS_TO_NANOS = 1000000;
+
     switch (type) {
       case 'int32':
       case 'int64':
         this.value = this.formatValue(new Date(value * 1000));
         break;
       case 'google.protobuf.Timestamp':
+        if (value && value.seconds > 0){
+          this.value = this.formatValue(new Date(value.seconds * 1000 + Math.round(value.nanos / MS_TO_NANOS)));
+        }
+        break;
+
       case 'string':
       default:
         if (value === '' || value === null || value === undefined) {

--- a/packages/furo-ui5/src/standard-type-renderers/display-google-protobuf-timestamp.js
+++ b/packages/furo-ui5/src/standard-type-renderers/display-google-protobuf-timestamp.js
@@ -4,7 +4,25 @@ import { Env } from '@furo/framework/src/furo.js';
 
 /**
  * `display-google-protobuf-timestamp`
- * The display-google-protobuf-timestamp component displays a FieldNode of type `google.prtobuf.Timestamp` in read only mode.
+ * The display-google-protobuf-timestamp component displays a FieldNode of type `google.protobuf.Timestamp` in read only mode.
+ *
+ * ```
+ * message Timestamp {
+ *  // Represents seconds of UTC time since Unix epoch
+ *  // 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
+ *  // 9999-12-31T23:59:59Z inclusive.
+ *  int64 seconds = 1;
+ *
+ *  // Non-negative fractions of a second at nanosecond resolution. Negative
+ *  // second values with fractions must still have non-negative nanos values
+ *  // that count forward in time. Must be from 0 to 999,999,999
+ *  // inclusive.
+ *  int32 nanos = 2;
+ * }
+ * ```
+ * If you have to represent timestamp using string type for legacy or compatibility reasons,
+ * the field names should not include any unit suffix.
+ * The string representation should use RFC 3339 format, e.g. "2014-07-30T10:43:17Z".
  *
  * The component uses locale from the environment to display the date value accordingly.
  * https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/format
@@ -66,36 +84,44 @@ class DisplayGoogleProtobufTimestamp extends LitElement {
   }
 
   /**
-   * convert date object to String according to Intl DateTimeFormat
+   * convert google.protobuf.Timestamp object to String according to Intl DateTimeFormat
    * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat
    * Example output: locale de-CH 15.01.2017, 02:30:15
    * @param fieldNode
    * @returns {string}
    * @private
    */
-  static _convertDateToString(fieldValue) {
+  static _convertTimestampString(fieldValue) {
+    const MS_TO_NANOS = 1000000;
+    let date;
     let strDate = '';
-    if (fieldValue) {
-      const date = new Date(fieldValue);
 
-      // eslint-disable-next-line eqeqeq
-      if (date != 'Invalid Date') {
-        strDate = Intl.DateTimeFormat([Env.locale, 'de-CH'], {
-          year: 'numeric',
-          month: '2-digit',
-          day: '2-digit',
-          hour: '2-digit',
-          minute: '2-digit',
-          second: '2-digit',
-        }).format(date);
+    if (typeof fieldValue === 'object') {
+      // google.protobuf.Timestamp
+      if (fieldValue && fieldValue.seconds > 0){
+        date = new Date(fieldValue.seconds * 1000 + Math.round(fieldValue.nanos / MS_TO_NANOS));
       }
+    } else {
+      // timestamp RFC 3339 e.g. 2014-07-30T10:43:17Z
+      date = new Date(fieldValue);
     }
 
+    // eslint-disable-next-line
+    if (date && date != 'Invalid Date') {
+      strDate = Intl.DateTimeFormat([Env.locale, 'de-CH'], {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+      }).format(date);
+    }
     return strDate;
   }
 
   _formatDisplay() {
-    this._displayValue = DisplayGoogleProtobufTimestamp._convertDateToString(this._field._value);
+    this._displayValue = DisplayGoogleProtobufTimestamp._convertTimestampString(this._field._value);
     this.requestUpdate();
   }
 

--- a/packages/furo-ui5/src/standard-type-renderers/display-google-protobuf-timestamp.js
+++ b/packages/furo-ui5/src/standard-type-renderers/display-google-protobuf-timestamp.js
@@ -98,7 +98,7 @@ class DisplayGoogleProtobufTimestamp extends LitElement {
 
     if (typeof fieldValue === 'object') {
       // google.protobuf.Timestamp
-      if (fieldValue && fieldValue.seconds > 0){
+      if (fieldValue && fieldValue.seconds > 0) {
         date = new Date(fieldValue.seconds * 1000 + Math.round(fieldValue.nanos / MS_TO_NANOS));
       }
     } else {

--- a/packages/furo-ui5/test/standard-type-renderers/display-google-protobuf-timestamp.test.js
+++ b/packages/furo-ui5/test/standard-type-renderers/display-google-protobuf-timestamp.test.js
@@ -44,11 +44,31 @@ describe('display-google-protobuf-timestamp', () => {
     }, 0);
   });
 
-  it('should show template according to the value of the data', done => {
+  it('should show template according to the value of the data. Empty value', done => {
     Env.locale = 'de';
-    dao.injectRaw({ google_timestamp: '1970-01-01T00:00:00Z' });
+    dao.injectRaw({ google_timestamp: { seconds: 0, nanos: 0 } });
     setTimeout(() => {
-      assert.equal(display._displayValue, '01.01.1970, 01:00:00');
+      assert.equal(display._displayValue, '');
+
+      done();
+    }, 110);
+  });
+
+  it('should show template according to the value of the data.', done => {
+    Env.locale = 'de';
+    dao.injectRaw({ google_timestamp: { seconds: 1621577867, nanos: 600000 } });
+    setTimeout(() => {
+      assert.equal(display._displayValue, '21.05.2021, 08:17:47');
+
+      done();
+    }, 110);
+  });
+
+  it('should handle timestamp string according RFC 3339', done => {
+    Env.locale = 'de';
+    dao.injectRaw({ google_timestamp: '2014-07-30T10:43:17Z' });
+    setTimeout(() => {
+      assert.equal(display._displayValue, '30.07.2014, 12:43:17');
 
       done();
     }, 110);


### PR DESCRIPTION
Currently, a google.protobuf.Timestamp is treated identically to a Timestamp String RFC 3339. In my opinion, this is wrong.

`message Timestamp {
   // Represents seconds of UTC time since Unix epoch
   // 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
   // 9999-12-31T23:59:59Z inclusive.
   int64 seconds = 1;
 
   // Non-negative fractions of a second at nanosecond resolution. Negative
   // second values with fractions must still have non-negative nanos values
   // that count forward in time. Must be from 0 to 999,999,999
   // inclusive.
   int32 nanos = 2;
 }`
 
There are systems that convert the google.protobuf.Timestamp to a string according RFC 3339. We should support both variants.

`{
  "seconds": 1621577867,
  "nanos": 0
}`

AND

`"2014-07-30T10:43:17Z`

With this PR the following components are affected:
- furo-ui5-data-date-time-picker
- display-google-protobuf-timestamp
- tests and demos

 